### PR TITLE
Show error message for invalid order ID

### DIFF
--- a/client/src/scenes/global/TrackingMenu.jsx
+++ b/client/src/scenes/global/TrackingMenu.jsx
@@ -21,6 +21,7 @@ const TrackingMenu = () => {
   const [order, setOrder] = useState([]);
   const [cart, setCart] = useState([]);
   const [totalPrice, setTotalPrice] = useState(0);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     let price = 0;
@@ -41,13 +42,15 @@ const TrackingMenu = () => {
           try {
             const response = await fetch(`http://localhost:1337/api/items/${item.id}?populate=image`);
             if (!response.ok) {
+              setError(true);
               return;
             }
             const data = await response.json();
             updatedCart.push(data.data);
             // Process the fetched data here
-            
+
           } catch (error) {
+            setError(true);
             return;
           }
         }
@@ -61,12 +64,14 @@ const TrackingMenu = () => {
     setOrder([]);
     setCart([]);
 
-    const response = await fetch(`http://localhost:1337/api/orders/${orderId}`);
-    if (!response.ok) {
-      return
-    }
-    const data = await response.json();
-    setOrder(data.data.attributes)
+    setError(false)
+      const response = await fetch(`http://localhost:1337/api/orders/${orderId}`);
+      if (!response.ok) {
+        setError(true)
+        return
+      }
+      const data = await response.json();
+      setOrder(data.data.attributes)
 
   };
 
@@ -125,6 +130,12 @@ const TrackingMenu = () => {
               Search
             </Typography>
           </Box>
+          {
+            error &&
+            <Typography sx={{ color: "red" }} >
+              Invalid Order Id —{" "} Try Again
+            </Typography>
+          }
           {
             cart != "" &&
             <Box>


### PR DESCRIPTION
### What I did
Introduced a new state variable named `error`. Now, whenever an error occurs while fetching information about the order for tracking purposes, the `error` variable is set to true. As a result, the "Invalid Order Id — Try Again" message is displayed, indicating that the entered order ID is invalid and prompting the user to try again.

Resolves #1 


### Output
![image](https://github.com/hamnarauf/Room-Charm/assets/77397009/35b8d6e0-a858-4261-bdfa-33281331cfeb)
